### PR TITLE
Updated bundle identifier from default example name

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -23,7 +23,7 @@ if (flutterVersionName == null) {
 }
 
 android {
-    namespace 'com.example.meesign_client'
+    namespace 'cz.muni.meesign'
 
     compileSdk 36
 
@@ -49,8 +49,7 @@ android {
     }
 
     defaultConfig {
-        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId "com.example.meesign_client"
+        applicationId "cz.muni.meesign"
         minSdkVersion 26
         targetSdkVersion 34
         versionCode flutterVersionCode.toInteger()

--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.meesign_client">
+    package="cz.muni.meesign">
     <!-- Flutter needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.meesign_client">
+    package="cz.muni.meesign">
     <uses-permission android:name="android.permission.NFC"/>
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.USE_BIOMETRIC"/>

--- a/android/app/src/main/kotlin/cz/muni/meesign/MainActivity.kt
+++ b/android/app/src/main/kotlin/cz/muni/meesign/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.example.meesign_client
+package cz.muni.meesign
 
 import io.flutter.embedding.android.FlutterFragmentActivity
 

--- a/android/app/src/profile/AndroidManifest.xml
+++ b/android/app/src/profile/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.meesign_client">
+    package="cz.muni.meesign">
     <!-- Flutter needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.10)
 project(runner LANGUAGES CXX)
 
 set(BINARY_NAME "meesign_client")
-set(APPLICATION_ID "com.example.meesign_client")
+set(APPLICATION_ID "cz.muni.meesign")
 
 cmake_policy(SET CMP0063 NEW)
 

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -479,7 +479,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.meesignClient.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = cz.muni.meesign.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/meesign_client.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/meesign_client";
@@ -494,7 +494,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.meesignClient.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = cz.muni.meesign.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/meesign_client.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/meesign_client";
@@ -509,7 +509,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.meesignClient.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = cz.muni.meesign.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/meesign_client.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/meesign_client";

--- a/macos/Runner/Configs/AppInfo.xcconfig
+++ b/macos/Runner/Configs/AppInfo.xcconfig
@@ -8,7 +8,7 @@
 PRODUCT_NAME = meesign_client
 
 // The application's bundle identifier
-PRODUCT_BUNDLE_IDENTIFIER = com.example.meesignClient
+PRODUCT_BUNDLE_IDENTIFIER = cz.muni.meesign
 
 // The copyright displayed in application information
-PRODUCT_COPYRIGHT = Copyright © 2024 com.example. All rights reserved.
+PRODUCT_COPYRIGHT = Copyright © 2024 cz.muni. All rights reserved.

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -113,6 +113,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.5"
+  change_app_package_name:
+    dependency: "direct main"
+    description:
+      name: change_app_package_name
+      sha256: "8e43b754fe960426904d77ed4c62fa8c9834deaf6e293ae40963fa447482c4c5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.5.0"
   characters:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -88,6 +88,7 @@ dev_dependencies:
   # activated in the `analysis_options.yaml` file located at the root of your
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
+  change_app_package_name: ^1.5.0
   flutter_lints: ^6.0.0
   flutter_test:
     sdk: flutter

--- a/windows/runner/Runner.rc
+++ b/windows/runner/Runner.rc
@@ -89,11 +89,11 @@ BEGIN
     BEGIN
         BLOCK "040904e4"
         BEGIN
-            VALUE "CompanyName", "com.example" "\0"
-            VALUE "FileDescription", "A new Flutter project." "\0"
+            VALUE "CompanyName", "cz.muni" "\0"
+            VALUE "FileDescription", "MeeSign client" "\0"
             VALUE "FileVersion", VERSION_AS_STRING "\0"
             VALUE "InternalName", "meesign_client" "\0"
-            VALUE "LegalCopyright", "Copyright (C) 2021 com.example. All rights reserved." "\0"
+            VALUE "LegalCopyright", "Copyright (C) 2021 cz.muni. All rights reserved." "\0"
             VALUE "OriginalFilename", "meesign_client.exe" "\0"
             VALUE "ProductName", "meesign_client" "\0"
             VALUE "ProductVersion", VERSION_AS_STRING "\0"


### PR DESCRIPTION
Project was still using the default **com.example.meesign** bundle identifier from the initial template. This PR updates it to
**cz.muni.meesign**

If the app is ever published to any store, this identifier will become permanent and we wont be able to change it without users having to reinstall the app.

If we add more supported targets in the future (eg iOS) we should use this bundle identifier as well to keep it consistent.